### PR TITLE
linjeskift påkrevd før tabell

### DIFF
--- a/SAMLAssertionV4.textile
+++ b/SAMLAssertionV4.textile
@@ -73,6 +73,7 @@ I tillegg kommer eventuelle attributter fra europeisk eID-intrastruktur, eIDAS /
 Vær oppmerksom på at noen land kan sende med ekstra attributter utover de som finst i eIDAS-standarden.  Disse vil bli prefixet med "eidas-landskode", og så videreformidlet av ID-porten.
 
 I tillegg utleverer vi et statusflagg for integrasjonen mot DSF:
+
 |_. Term |_. Beskrivelse |_. Kardinalitet |
 | "status-dsf":/Felles/status-dsf  | Kodeverk for "status-dsf":#status-dsf | 0..1 |
 

--- a/SAMLAssertionV4.textile
+++ b/SAMLAssertionV4.textile
@@ -108,7 +108,7 @@ h4. status-dsf
 |_. Kodeverdi |_. Beskrivelse |
 | OK | ID-porten har som del av innlogging gjennomført en spørring mot DSF uten tekniske feil|
 | SYSTEMFEIL	| ID-porten har ikke tilgang til informasjon fra Det Sentrale Folkeregisteret , f.eks. ved feil i integrasjon mot registrert. |
-| DUPLIKAT | Oppslag mot DSF har resultert i flere mulige treff, og ID-porten kan ikke gjøre en garantert kobling mellom utenlandsk eID og D-nummer i DSF |
+| FLERETREFF | Oppslag mot DSF har resultert i flere mulige treff, og ID-porten kan ikke gjøre en garantert kobling mellom utenlandsk eID og D-nummer i DSF |
 
 
 h4. Eksempel


### PR DESCRIPTION
endre navn på kodeverk frå DUPLIKAT til FLERETREFF
typo: textile-formatet krever visst eit linjeskift før ein tabell, elles vert det inline-tekst.